### PR TITLE
Remove pinned Chromium version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,10 +19,9 @@ RUN gauge -v \
      && gauge install screenshot \
      && gauge install spectacle
 
-ARG CHROMIUM_VERSION="83.0.4103.116-1~deb10u3"
 # [Optional] Uncomment this section to install additional OS packages.
 RUN  apt-get update && export DEBIAN_FRONTEND=noninteractive \
-   && apt-get -y install --no-install-recommends chromium=${CHROMIUM_VERSION} \
+   && apt-get -y install --no-install-recommends chromium \
 # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
This commit will change the install of Chromium on
the devcontainer to no longer be a pinned version.

Reason for this change is that the pinned version
was no longer available, and we have no way at
present of automatically updating the pinned
version specified.