### PR TITLE
Pin chromedriver-binary to chrome v 88

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 getgauge
 selenium
-chromedriver-binary==83.0.4103.39
+chromedriver-binary==88.0.4324.96


### PR DESCRIPTION
We need to pin chromedriver-binary to the same major Chrome version that
is installed in the devcontainer. The list of chromedriver-binary
versions corresponding to the major Chrome versions is [here][1]

[1]: https://sites.google.com/a/chromium.org/chromedriver/downloads